### PR TITLE
fix: netlify 404 — add Hugo build command with correct baseURL

### DIFF
--- a/.github/workflows/deploy-netlify.yml
+++ b/.github/workflows/deploy-netlify.yml
@@ -19,7 +19,7 @@ jobs:
           extended: true
 
       - name: Build
-        run: cd site && hugo --minify
+        run: cd site && hugo --minify --baseURL https://content-empire-tdsquad.netlify.app/
 
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v3

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,9 @@
 [build]
+  command = "cd site && hugo --minify --baseURL https://content-empire-tdsquad.netlify.app/"
   publish = "docs"
+
+[build.environment]
+  HUGO_VERSION = "0.147.0"
 
 [[headers]]
   for = "/*"


### PR DESCRIPTION
## Problem
The Netlify site at content-empire-tdsquad.netlify.app was 404ing because:
- \
etlify.toml\ had no build command — Netlify served the stale pre-built \docs/\ unchanged
- The pre-built \docs/\ was built with \aseURL = 'https://tdsquadai.github.io/content-empire/'\
- All navigation links in the HTML pointed to GitHub Pages, not Netlify → 404s on any sub-page click

## Fix
- Add \command = 'cd site && hugo --minify --baseURL https://content-empire-tdsquad.netlify.app/'\ to \
etlify.toml\
- Add \HUGO_VERSION = '0.147.0'\ env var so Netlify uses the correct Hugo version
- Fix \deploy-netlify.yml\ GitHub Actions to also pass \--baseURL\ flag